### PR TITLE
Release v0.1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+
+0.1.8 / 2015-01-16
+==================
+
+  * SECURITY: Perform constant time string comparison when validating signatures

--- a/lib/signature/version.rb
+++ b/lib/signature/version.rb
@@ -1,3 +1,3 @@
 module Signature
-  VERSION = "0.1.7"
+  VERSION = "0.1.8"
 end


### PR DESCRIPTION
Bumping version, introducing a changelog.

This library deserves a 1.0 release though since the interface is likely stable.