### PR TITLE
Compatibility with Ruby 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ rvm:
   - 1.9.2
   - 1.9.3
   - 2.0.0
+  - 2.2.0
   - jruby-18mode
   - jruby-19mode
   - rbx-18mode

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GEM
       eventmachine
       rspec (> 2.6.0)
       test-unit
-    eventmachine (1.0.3)
+    eventmachine (1.0.7)
     rspec (2.13.0)
       rspec-core (~> 2.13.0)
       rspec-expectations (~> 2.13.0)


### PR DESCRIPTION
Updated dev-dependency eventmachine 1.0.3 -> 0.1.7
Fixes Ruby 2.2 compatibility see https://github.com/eventmachine/eventmachine/pull/503